### PR TITLE
Bump up the max on the fingerprint

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -23,7 +23,7 @@ import sys
 # The constants in system_properties.h includes the termination NUL,
 # so we decrease the values by 1 here.
 PROP_NAME_MAX = 31
-PROP_VALUE_MAX = 95
+PROP_VALUE_MAX = 200
 
 # Put the modifications that you need to make into the /system/build.prop into this
 # function. The prop object has get(name) and put(name,value) methods.


### PR DESCRIPTION
We don't anticipate a fingerprint being over 200 characters but this is
more or less to fool proof this. The max was set at 95 previously and we
figured that was more than enough BUT boy were we wrong lol

This unbreaks the shieldtablet and makes it compile!

Change-Id: Ia07bfd4b6d6c058ee8aa4351abf5583372a8b862