### PR TITLE
envsetup: add mk_timer

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -567,7 +567,7 @@ function brunch()
 {
     breakfast $*
     if [ $? -eq 0 ]; then
-        time mka bacon
+        mka bacon
     else
         echo "Do you know what you're doing?"
         return 1
@@ -1664,7 +1664,7 @@ function mka() {
             make -j `sysctl hw.ncpu|cut -d" " -f2` "$@"
             ;;
         *)
-            schedtool -B -n 1 -e ionice -n 1 make -j `cat /proc/cpuinfo | grep "^processor" | wc -l` "$@"
+            mk_timer schedtool -B -n 1 -e ionice -n 1 make -j$(cat /proc/cpuinfo | grep "^processor" | wc -l) "$@"
             ;;
     esac
 }
@@ -1765,10 +1765,10 @@ function get_make_command()
   echo command make
 }
 
-function make()
+function mk_timer()
 {
     local start_time=$(date +"%s")
-    $(get_make_command) "$@"
+    $@
     local ret=$?
     local end_time=$(date +"%s")
     local tdiff=$(($end_time-$start_time))
@@ -1801,6 +1801,11 @@ function make()
     echo " ####${color_reset}"
     echo
     return $ret
+}
+
+function make()
+{
+    mk_timer $(get_make_command) "$@"
 }
 
 function provision()


### PR DESCRIPTION
this wraps around any method call, mainly for 'make'.

mka needs this on linux, since ionice and schedtool don't
respect functions

Change-Id: If8cdd235ed9eba377dd90ab8b12e93036a377ea5